### PR TITLE
Fix Symfony 3.1 depreciation notice

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -7,6 +7,6 @@ services:
 
     # twig
     shapecode.twig_string_loader.twig_loader.string:
-        class: %shapecode.twig_string_loader.twig_loader.string.class%
+        class: '%shapecode.twig_string_loader.twig_loader.string.class%'
         tags:
             - { name: twig.loader }


### PR DESCRIPTION
Not quoting the scalar "%shapecode.twig_string_loader.twig_loader.string.class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0.